### PR TITLE
Alterado para não usar mais o GenericService

### DIFF
--- a/client/src/app/services/usuario/usuario.service.ts
+++ b/client/src/app/services/usuario/usuario.service.ts
@@ -1,9 +1,9 @@
+import { Usuario } from './../../models/Usuario';
 import { Injectable } from '@angular/core';
 import { SuperService } from '../super.service';
 import { environment } from '../../../environments/environment';
-import {Observable} from "rxjs/Observable";
+import { Observable } from "rxjs/Observable";
 import { HttpClient } from '@angular/common/http';
-import {Usuario} from "../../models/Usuario";
 
 @Injectable()
 export class UsuarioService extends SuperService {
@@ -15,7 +15,7 @@ export class UsuarioService extends SuperService {
     }
 
     getUsuarioLogged(): Observable<Usuario> {
-        return this.httpClient.get<Usuario>(this.apiUrl + 'auth/getusuariobytoken');
+        return this.httpClient.get<Usuario>(`${this.apiUrl}auth/getusuariobytoken`);
     }
 
     // updateSenha(senha: string, novaSenha: string): Observable<Boolean> {
@@ -23,4 +23,7 @@ export class UsuarioService extends SuperService {
     //     return this.httpClient.get<Boolean>(url);
     // }
 
+    getAll(): Observable<Usuario[]> {
+        return this.httpClient.get<Usuario[]>(`${this.apiUrl}usuario`);
+    }
 }

--- a/client/src/app/views/usuario/usuario.component.ts
+++ b/client/src/app/views/usuario/usuario.component.ts
@@ -1,9 +1,9 @@
+import { UsuarioService } from './../../services/usuario/usuario.service';
 import { ModalUsuarioComponent } from './modal/modal-user.component';
 import { Usuario } from './../../models/Usuario';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Component, OnInit } from '@angular/core';
 import { MatIconRegistry, MatDialog } from "@angular/material";
-import { GenericService } from './../../services/generic/generic.service';
 
 
 @Component({
@@ -23,7 +23,7 @@ export class UsuarioComponent implements OnInit {
 
 	
 	getAll() {
-		this.genercService.getAll('usuario').subscribe(usuarios => {
+		this.usuarioService.getAll().subscribe(usuarios => {
 			this.usuarios = <Usuario[]>usuarios;
 			this.filteredUsuarios = Object.assign([], this.usuarios);
 			this.selectedUsuario = this.usuarios[0];
@@ -36,7 +36,7 @@ export class UsuarioComponent implements OnInit {
 	constructor(
 		iconRegistry: MatIconRegistry, 
 		sanitizer: DomSanitizer, 
-		private genercService: GenericService,
+		private usuarioService: UsuarioService,
 		private dialog: MatDialog
 	) {
 		// To avoid XSS attacks, the URL needs to be trusted from inside of your application.


### PR DESCRIPTION
De agora em diante é necessário usar o httpClient ao invés de http, por isso não vamos usar o genericService. Crie um service para cada model que for realizar interação no banco de dados. 
Pode usar como exemplo os fontes alterados neste commit

usuario.service.ts
e usuario.component.ts